### PR TITLE
Accept YAML/JSON files as documents

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,13 +7,13 @@
   "dependencies": {
     "front-matter": "1.0.0",
     "gulp-util": "3.0.4",
+    "js-yaml": "3.3.1",
     "lodash.assign": "3.2.0",
     "swig": "1.4.2",
     "through2": "0.6.5"
   },
   "devDependencies": {
     "chai": "2.3.0",
-    "js-yaml": "3.3.1",
     "mocha": "2.2.5",
     "stream-array": "1.1.0",
     "stream-assert": "2.0.2"

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ module.exports = function(options) {
     swig:          swig,
     template:      'template',
     draft:         false,
+    dataDocument:  [],
   }, options);
 
   // ===

--- a/test/main.js
+++ b/test/main.js
@@ -9,10 +9,11 @@ var minisite = require('../src');
 var create = function(filename, attr, body) {
   var contents = [];
 
-  if (attr) {
-    contents.push('---', yaml.safeDump(attr), '---');
-  }
-  if (body !== undefined) {
+  if (attr && body !== undefined) {
+    contents.push('---', yaml.safeDump(attr), '---', body);
+  } else if (attr) {
+    contents.push(yaml.safeDump(attr));
+  } else if (body !== undefined) {
     contents.push(body);
   }
   var content = contents.join('\n');
@@ -158,6 +159,33 @@ describe('gulp-minisite', function() {
           expect(e.message).to.have.string('same path');
           done();
         });
+    });
+
+    it('should accept YAML as document', function(done) {
+      array([create('hello.yaml', {
+        title: 'Hello',
+        description: 'Hello World',
+      })])
+        .pipe(minisite({dataDocument: ['yaml']}))
+        .pipe(assert.length(1))
+        .pipe(assert.first(function(file) {
+          expect(file.path).to.equal('/root/base/hello/index.html');
+          expect(file.data.title).to.equal('Hello');
+          expect(file.data.description).to.equal('Hello World');
+        }))
+        .pipe(assert.end(done));
+    });
+
+    it('should accept JSON as document', function(done) {
+      array([create('hello.json', null, '{"title":"Hello","description":"Hello World"}')])
+        .pipe(minisite({dataDocument: ['json']}))
+        .pipe(assert.length(1))
+        .pipe(assert.first(function(file) {
+          expect(file.path).to.equal('/root/base/hello/index.html');
+          expect(file.data.title).to.equal('Hello');
+          expect(file.data.description).to.equal('Hello World');
+        }))
+        .pipe(assert.end(done));
     });
 
   });


### PR DESCRIPTION
Currently only text files with front-matter are considered as document files. In addition to it, take *.{yaml,yml,json} files as documents without body.