### PR TITLE
[WIP] Disable Swig cache

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,8 @@ var yaml        = require('js-yaml');
 
 var parse = require('./parse');
 
+swig.setDefaults({cache: false});
+
 module.exports = function(options) {
 
   options = assign({


### PR DESCRIPTION
Swig’s cache prevents refreshing output.